### PR TITLE
ensure a release to npm is only executed on the master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ jobs:
         on:
           tags: true
           repo: tgrowden/takeout-to-geojson
+          branch: master
 
     - stage: gh pages
       script: yarn docs && touch docs/.nojekyll


### PR DESCRIPTION
Due to improper configuration, releases to NPM were being made when a new tag was pushed on _any_ branch; this fix restricts the releases to just `master`.